### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,6 +10,9 @@ class Item < ApplicationRecord
   belongs_to_active_hash :estimatedArrival
   belongs_to_active_hash :deliveryFee
 
+  default_scope -> { order(created_at: :desc) }
+
+
   with_options numericality: { other_than: 1 } do
     validates :category_id
     validates :status_id

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,7 +12,6 @@ class Item < ApplicationRecord
 
   default_scope -> { order(created_at: :desc) }
 
-
   with_options numericality: { other_than: 1 } do
     validates :category_id
     validates :status_id

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,8 +125,6 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -154,10 +152,8 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      
+      <% if @items = nil %>
         <li class='list'>
           <%= link_to '#' do %>
           <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -173,10 +169,9 @@
               </div>
             </div>
         </div>
-        <% end %>
-      
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+         <% end %>
+         </li>
+         <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -121,10 +121,12 @@
   <%# /FURIMAの特徴 %>
 
   <%# 商品一覧 %>
+  <%#商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+    <% if @items != nil %>
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -152,8 +154,9 @@
         <% end %>
       </li>
       <% end %>
+    <% end %>
       <%# 商品がない場合のダミー %>
-      <% if @items = nil %>
+      <% if @items == nil %>
         <li class='list'>
           <%= link_to '#' do %>
           <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,24 +127,24 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
-
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_fee_id %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,26 +153,28 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
-          </div>
         </div>
         <% end %>
+      
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :items, only: [:new,:create]
+  resources :items, only: [:index,:new,:create]
 end


### PR DESCRIPTION
#What
商品一覧表示機能の実装
商品の表示順（降順）・item情報　https://gyazo.com/aa70098cbae0a2554b6cd656ff599fab
ログイン外からの確認https://gyazo.com/fc8f6d0ac3878fdb60f98611235875ca
商品がない場合の分岐設定後の投稿一覧https://gyazo.com/648ff59e93be1a0af5146eed81831b8c

条件分岐修正後の投稿一覧https://gyazo.com/2fca9db7bcb6882924b52335b385a1a9

#Why
商品一覧表示機能実装のため